### PR TITLE
IsDNSZoneMaintained returns inverted value

### DIFF
--- a/src/include/dhcp-server/dns-server-dialogs.rb
+++ b/src/include/dhcp-server/dns-server-dialogs.rb
@@ -30,7 +30,7 @@ module Yast
       all_zones = DnsServerAPI.GetZones
 
       # found or not?
-      Ops.get(all_zones, zone_name) == nil
+      Ops.get(all_zones, zone_name) != nil
     end
 
     def IsDNSZoneMaster(zone_name)


### PR DESCRIPTION
The Function IsDNSZoneMaintained is returning true if the Zone is not maintained and otherwise around.